### PR TITLE
Always create UDS sockets in temporary folders

### DIFF
--- a/aioros/_utils/_sockets.py
+++ b/aioros/_utils/_sockets.py
@@ -1,5 +1,3 @@
-import os
-import platform
 from pathlib import Path
 from tempfile import mkdtemp
 from typing import Optional, Tuple, cast
@@ -24,12 +22,7 @@ async def create_tcp_listener(
 async def create_unix_listener(
     local_host: str, node_name: str, path: Optional[Path], fmt: str
 ) -> Tuple[SocketListener, str]:
-    if platform.system() == "Linux":
-        path = path or Path(
-            "/run/user", str(os.getuid()), str(os.getpid()), node_name[1:]
-        )
-    else:
-        path = Path(mkdtemp(), node_name[1:], "socket")
+    path = path or Path(mkdtemp(), node_name[1:], "socket")
 
     path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
/var/run is managed by systemd and does not exist on systems
without (Docker & WSL).

Fixes #1